### PR TITLE
#35 Fix default theme names

### DIFF
--- a/packages/theme_tailor/example/lib/themes_name_collision.dart
+++ b/packages/theme_tailor/example/lib/themes_name_collision.dart
@@ -5,10 +5,11 @@ part 'themes_name_collision.tailor.dart';
 
 @tailor
 class $_SimpleTheme {
+  @themeExtension
   static List<AnotherTheme> anotherTheme = AnotherTheme.tailorThemes;
 }
 
-@tailor
+@tailorComponent
 class $_AnotherTheme {
   static List<Color> themes = [Colors.amber, Colors.blueGrey.shade800];
 }

--- a/packages/theme_tailor/example/pubspec.lock
+++ b/packages/theme_tailor/example/pubspec.lock
@@ -414,7 +414,7 @@ packages:
       path: "../../theme_tailor_annotation"
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.3"
   timing:
     dependency: transitive
     description:

--- a/packages/theme_tailor/lib/src/generator/theme_tailor_generator.dart
+++ b/packages/theme_tailor/lib/src/generator/theme_tailor_generator.dart
@@ -154,17 +154,20 @@ class ThemeTailorGenerator extends GeneratorForAnnotation<Tailor> {
 
   List<String> _computeThemes(ConstantReader annotation) {
     if (!annotation.read('themes').isNull) {
-      return List<String>.from(
-        annotation.read('themes').listValue.map((e) => e.toStringValue()),
-      );
+      return annotation
+          .read('themes')
+          .listValue
+          .map((e) => e.toStringValue())
+          .whereNotNull()
+          .toList();
     }
-    var pubThemes = (builderOptions.config['themes'] as List)
-        .map((element) => element.toString())
-        .toList();
+
+    var pubThemes = builderOptions.config['themes'] as List<dynamic>?;
 
     const defaultThemes = ['light', 'dark'];
+    if (pubThemes == null) return defaultThemes;
 
-    return pubThemes.isNotEmpty ? pubThemes : defaultThemes;
+    return pubThemes.whereNotNull().map((e) => e.toString()).toList();
   }
 
   ExtensionData _computeThemeGetter(ConstantReader annotation) {


### PR DESCRIPTION
Fixes https://github.com/Iteo/theme_tailor/issues/35 
No build.yaml config caused the generator to crash. In the example folder build.config is used and it obscured the problem (Additional package without build.config can be created later) 

Additional changes:
- Cleanup example folder (Wrong annotations that caused to generate dynamic theme instead)