### PR TITLE
support latest analyser (5.1.0)

### DIFF
--- a/packages/theme_tailor/lib/src/util/extension/element_annotation_extension.dart
+++ b/packages/theme_tailor/lib/src/util/extension/element_annotation_extension.dart
@@ -10,6 +10,6 @@ extension ElementAnnotationExtension on ElementAnnotation {
 
   bool get isTailorThemeExtension {
     return TypeChecker.fromRuntime(themeExtension.runtimeType)
-        .isAssignableFrom(computeConstantValue()!.type!.element!);
+        .isAssignableFrom(computeConstantValue()!.type!.element2!);
   }
 }

--- a/packages/theme_tailor/lib/src/util/extension/field_declaration_extension.dart
+++ b/packages/theme_tailor/lib/src/util/extension/field_declaration_extension.dart
@@ -1,7 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 
 extension FieldDeclarationExtension on FieldDeclaration {
-  String get name => fields.variables.first.name.name;
+  String get name => fields.variables.first.name.toString();
 
   List<String> get annotations {
     return metadata.map((e) => e.toString()).toList(growable: false);

--- a/packages/theme_tailor/lib/src/util/import_finder.dart
+++ b/packages/theme_tailor/lib/src/util/import_finder.dart
@@ -28,7 +28,7 @@ class ImportFinder {
   /// lib/src/dart/element/element.dart
   bool recursiveSearch() {
     final libraries = <LibraryElementWithVisibility>{};
-    for (final import in lib.imports) {
+    for (final import in lib.libraryImports) {
       final library = import.importedLibrary;
       if (library != null) {
         libraries.add(LibraryElementWithVisibility.root(
@@ -100,7 +100,7 @@ class LibraryElementWithVisibility {
   /// lib/src/dart/element/element.dart
   List<LibraryElementWithVisibility> get exportedLibraries {
     final libraries = <LibraryElementWithVisibility>{};
-    for (final export in lib.exports) {
+    for (final export in lib.libraryExports) {
       final library = export.exportedLibrary;
       if (library != null) {
         libraries.add(LibraryElementWithVisibility(

--- a/packages/theme_tailor/lib/src/util/theme_encoder_helper.dart
+++ b/packages/theme_tailor/lib/src/util/theme_encoder_helper.dart
@@ -10,7 +10,8 @@ const themeEncoderChecker = TypeChecker.fromRuntime(ThemeEncoder);
 
 ThemeEncoderData? extractThemeEncoderData(
     ElementAnnotation? annotation, DartObject constantValue) {
-  final encoderClassElement = constantValue.type!.element as ClassElement;
+  final encoderClassElement = constantValue.type!.element2 as ClassElement;
+  if (encoderClassElement == null) return null;
 
   final encoderSuper = encoderClassElement.allSupertypes.singleWhereOrNull((e) {
     return themeEncoderChecker.isExactlyType(e);
@@ -26,7 +27,7 @@ ThemeEncoderData? extractThemeEncoderData(
 
   final annotationElement = annotation?.element;
   if (annotationElement is PropertyAccessorElement) {
-    final enclosing = annotationElement.enclosingElement;
+    final enclosing = annotationElement.enclosingElement3;
 
     var accessString = annotationElement.name;
 
@@ -52,7 +53,7 @@ ThemeEncoderData? extractThemeEncoderData(
   }
 
   return ThemeEncoderData.className(
-    constantValue.type!.element!.name!,
+    constantValue.type!.element2!.name!,
     reviver.accessor,
     encoderTypeStr,
     genericTypeArg != null,


### PR DESCRIPTION
otherwize it generates the following:

```
flutter packages pub run build_runner watch --delete-conflicting-outputs
[INFO] Generating build script...
[INFO] Generating build script completed, took 186ms

[INFO] Setting up file watchers...
[INFO] Setting up file watchers completed, took 4ms

[INFO] Waiting for all file watchers to be ready...
[INFO] Waiting for all file watchers to be ready completed, took 200ms

[INFO] Initializing inputs
[INFO] Reading cached asset graph...
[WARNING] Throwing away cached asset graph because the language version of some package(s) changed. This would most commonly happen when updating dependencies or changing your min sdk constraint.
[INFO] Cleaning up outputs from previous builds....
[INFO] Cleaning up outputs from previous builds. completed, took 5ms

[INFO] Terminating. No further builds will be scheduled

[INFO] Builds finished. Safe to exit

[INFO] Generating build script...
[INFO] Generating build script completed, took 54ms

[WARNING] Invalidated precompiled build script due to missing asset graph.
[INFO] Precompiling build script......
[WARNING] ../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/extension/element_annotation_extension.dart:13:57: Error: The getter 'element' isn't defined for the class 'DartType'.
 - 'DartType' is from 'package:analyzer/dart/element/type.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/type.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'element'.
        .isAssignableFrom(computeConstantValue()!.type!.element!);
                                                        ^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/extension/field_declaration_extension.dart:4:50: Error: The getter 'name' isn't defined for the class 'Token'.
 - 'Token' is from 'package:_fe_analyzer_shared/src/scanner/token.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/_fe_analyzer_shared-49.0.0/lib/src/scanner/token.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'name'.
  String get name => fields.variables.first.name.name;
                                                 ^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/theme_encoder_helper.dart:13:51: Error: The getter 'element' isn't defined for the class 'DartType'.
 - 'DartType' is from 'package:analyzer/dart/element/type.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/type.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'element'.
  final encoderClassElement = constantValue.type!.element as ClassElement;
                                                  ^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/theme_encoder_helper.dart:29:41: Error: The getter 'enclosingElement' isn't defined for the class 'PropertyAccessorElement'.
 - 'PropertyAccessorElement' is from 'package:analyzer/dart/element/element.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/element.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'enclosingElement'.
    final enclosing = annotationElement.enclosingElement;
                                        ^^^^^^^^^^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/theme_encoder_helper.dart:55:25: Error: The getter 'element' isn't defined for the class 'DartType'.
 - 'DartType' is from 'package:analyzer/dart/element/type.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/type.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'element'.
    constantValue.type!.element!.name!,
                        ^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/import_finder.dart:31:30: Error: The getter 'imports' isn't defined for the class 'LibraryElement'.
 - 'LibraryElement' is from 'package:analyzer/dart/element/element.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/element.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'imports'.
    for (final import in lib.imports) {
                             ^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/theme_tailor-1.0.7/lib/src/util/import_finder.dart:103:30: Error: The getter 'exports' isn't defined for the class 'LibraryElement'.
 - 'LibraryElement' is from 'package:analyzer/dart/element/element.dart' ('../../../flutter/.pub-cache/hosted/pub.dartlang.org/analyzer-5.1.0/lib/dart/element/element.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'exports'.
    for (final export in lib.exports) {
                             ^^^^^^^
[INFO] Precompiling build script... completed, took 538ms

[SEVERE] Failed to precompile build script .dart_tool/build/entrypoint/build.dart.
This is likely caused by a misconfigured builder definition.
```