### PR TITLE
basic documentation comments are now copied into generated class and …

### DIFF
--- a/packages/theme_tailor/lib/src/generator/theme_tailor_generator.dart
+++ b/packages/theme_tailor/lib/src/generator/theme_tailor_generator.dart
@@ -53,6 +53,7 @@ class ThemeTailorGenerator extends GeneratorForAnnotation<Tailor> {
 
     final className = element.name;
     final themes = _computeThemes(annotation);
+
     final themeGetter = _computeThemeGetter(annotation);
     final requireConstThemes = annotation.read('requireStaticConst').boolValue;
 
@@ -291,6 +292,7 @@ class _TailorClassVisitor extends SimpleElementVisitor {
         typeName: coreType.getDisplayString(withNullability: true),
         implementsThemeExtension: implementsThemeExtension,
         isTailorThemeExtension: hasThemeExtensionAnnotation,
+        documentationComment: element.documentationComment,
       );
     }
   }

--- a/packages/theme_tailor/lib/src/model/field.dart
+++ b/packages/theme_tailor/lib/src/model/field.dart
@@ -5,6 +5,7 @@ class Field {
     required this.implementsThemeExtension,
     required this.isTailorThemeExtension,
     this.values,
+    this.documentationComment,
   });
 
   final String name;
@@ -12,6 +13,7 @@ class Field {
   final bool implementsThemeExtension;
   final bool isTailorThemeExtension;
   final List<String>? values;
+  final String? documentationComment;
 
   bool get isNullable => typeName.contains('?');
 
@@ -21,6 +23,7 @@ class Field {
     bool? implementsThemeExtension,
     bool? isTailorThemeExtension,
     List<String>? values,
+    String? documentationComment,
   }) {
     return Field(
       name: name ?? this.name,
@@ -30,6 +33,7 @@ class Field {
       isTailorThemeExtension:
           isTailorThemeExtension ?? this.isTailorThemeExtension,
       values: values ?? this.values,
+      documentationComment: documentationComment ?? this.documentationComment,
     );
   }
 }

--- a/packages/theme_tailor/lib/src/template/getter_template.dart
+++ b/packages/theme_tailor/lib/src/template/getter_template.dart
@@ -3,12 +3,16 @@ class GetterTemplate {
     required this.type,
     required this.name,
     required this.accessor,
+    this.documentationComment,
   });
 
   final String type;
   final String name;
   final String accessor;
+  final String? documentationComment;
 
   @override
-  String toString() => '$type get $name => $accessor;';
+  String toString() => documentationComment != null
+      ? '$documentationComment\n$type get $name => $accessor;'
+      : '$type get $name => $accessor;';
 }

--- a/packages/theme_tailor/lib/src/template/theme_class_template.dart
+++ b/packages/theme_tailor/lib/src/template/theme_class_template.dart
@@ -26,6 +26,11 @@ class ThemeClassTemplate {
       constructorBuffer.write('required this.$key,');
       fieldsBuffer
         ..write(config.annotationManager.expandFieldAnnotations(key))
+        ..write(
+          value.documentationComment != null
+              ? '${value.documentationComment}\n'
+              : '',
+        )
         ..write('final ${value.typeName} $key;');
     });
 

--- a/packages/theme_tailor/lib/src/template/theme_extension_template.dart
+++ b/packages/theme_tailor/lib/src/template/theme_extension_template.dart
@@ -35,6 +35,7 @@ class ThemeExtensionTemplate {
           type: prop.value.typeName,
           name: prop.key,
           accessor: '$themeGetterName.${prop.key}',
+          documentationComment: prop.value.documentationComment,
         ));
       }
     }


### PR DESCRIPTION
…context getters
adding comments in source file:
![source_file](https://user-images.githubusercontent.com/43029034/200539920-b3046cd9-4c42-48e5-90a1-db4447484cc1.png)
results in:
![generated_p1](https://user-images.githubusercontent.com/43029034/200539918-3203bfb4-3ddf-48d5-aaa6-a18b96fa738f.png)
![generated_p2](https://user-images.githubusercontent.com/43029034/200539908-02f7d443-401a-4985-8a0b-43bd4eaced18.png)


