### PR TITLE
Add type from ast if appears to be dynamic

### DIFF
--- a/packages/theme_tailor/example/pubspec.lock
+++ b/packages/theme_tailor/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "47.0.0"
+    version: "50.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.7.0"
+    version: "5.2.0"
   args:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
@@ -147,7 +147,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   fake_async:
     dependency: transitive
     description:
@@ -234,14 +234,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "6.5.4"
   logging:
     dependency: transitive
     description:
@@ -344,7 +344,7 @@ packages:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   source_span:
     dependency: transitive
     description:
@@ -400,7 +400,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.7"
+    version: "1.0.8"
   theme_tailor_annotation:
     dependency: "direct main"
     description:

--- a/packages/theme_tailor/example/pubspec.yaml
+++ b/packages/theme_tailor/example/pubspec.yaml
@@ -8,20 +8,19 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  analyzer: ^5.2.0
   collection: ^1.16.0
   flutter:
     sdk: flutter
 
-  json_annotation: ^4.5.0
+  json_annotation: ^4.7.0
   theme_tailor_annotation: ^1.0.0
-
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.1.11
-
-  json_serializable: ^6.2.0
+  json_serializable: ^6.5.4
   theme_tailor: ^1.0.3
 
 flutter:

--- a/packages/theme_tailor/lib/src/generator/theme_tailor_generator.dart
+++ b/packages/theme_tailor/lib/src/generator/theme_tailor_generator.dart
@@ -85,8 +85,10 @@ class ThemeTailorGenerator extends GeneratorForAnnotation<Tailor> {
     classAstNode.visitChildren(astVisitor);
 
     for (final typeEntry in astVisitor.fieldTypes.entries) {
-      final field = fields[typeEntry.key]!;
-      fields[typeEntry.key] = field.copyWith(typeName: typeEntry.value);
+      final fieldValue = fields[typeEntry.key];
+      if (fieldValue != null) {
+        fields[typeEntry.key] = fieldValue.copyWith(typeName: typeEntry.value);
+      }
     }
 
     final fieldInitializerVisitor = _TailorFieldInitializerVisitor(
@@ -134,10 +136,8 @@ class ThemeTailorGenerator extends GeneratorForAnnotation<Tailor> {
       final astAnnotations = <String>[];
 
       entry.value.forEachIndexed((i, isInternal) {
-        late final value = astVisitor.rawFieldsAnnotations[entry.key]?[i];
-        if (!isInternal && value != null) {
-          astAnnotations.add(value);
-        }
+        late final value = astVisitor.rawFieldsAnnotations[entry.key]![i];
+        if (!isInternal) astAnnotations.add(value);
       });
       fieldLevelAnnotations[entry.key] = astAnnotations;
     }

--- a/packages/theme_tailor/lib/src/util/extension/library_element_extension.dart
+++ b/packages/theme_tailor/lib/src/util/extension/library_element_extension.dart
@@ -2,11 +2,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:theme_tailor/src/util/import_finder.dart';
 
 extension LibraryElementExtension on LibraryElement {
-  bool get hasFlutterDiagnosticableImport {
-    return ImportFinder(
-      lib: this,
-      whereElement: isClass('Diagnosticable'),
-      whereLibrary: isWithinLibrary('flutter'),
-    ).recursiveSearch();
-  }
+  bool get hasFlutterDiagnosticableImport => liraryExports(
+        className: 'DiagnosticableTreeMixin',
+        fromPackage: 'flutter',
+      );
 }

--- a/packages/theme_tailor/lib/src/util/import_finder.dart
+++ b/packages/theme_tailor/lib/src/util/import_finder.dart
@@ -1,124 +1,197 @@
+// Based of freezed's "recursive_import_locator.dart" (https://pub.dev/packages/freezed)
+// https://github.com/rrousselGit/freezed/blob/master/packages/freezed/lib/src/tools/recursive_import_locator.dart
+//
+// MIT License
+//
+// Copyright (c) 2020 Remi Rousselet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 import 'package:analyzer/dart/element/element.dart';
+import 'package:collection/collection.dart';
 
-typedef Matcher<T> = bool Function(T e);
-
-typedef ElementMatcher = Matcher<Element>;
-typedef LibraryMatcher = Matcher<LibraryElement>;
-
-ElementMatcher isClass(String name) {
-  return (e) => e is ClassElement && e.name == name;
-}
-
-ElementMatcher isWithinLibrary(String name) {
-  return (e) => e.librarySource!.fullName.startsWith('/$name/');
-}
-
-class ImportFinder {
-  ImportFinder({
-    required this.lib,
-    required this.whereElement,
-    this.whereLibrary,
-  });
-
-  final LibraryElement lib;
-  final ElementMatcher whereElement;
-  final LibraryMatcher? whereLibrary;
-
-  /// based on importedLibraries from analyzer-4.1.0
-  /// lib/src/dart/element/element.dart
-  bool recursiveSearch() {
-    final libraries = <LibraryElementWithVisibility>{};
-    for (final import in lib.libraryImports) {
-      final library = import.importedLibrary;
-      if (library != null) {
-        libraries.add(LibraryElementWithVisibility.root(
-          library,
-          import.combinators,
-        ));
-      }
-    }
-
-    return libraries.any((lib) => _isExportedRecursivaly(
-          lib,
-          {lib.lib.librarySource.fullName},
-        ));
+extension FindAllAvailableTopLevelElements on LibraryElement {
+  bool isFromPackage(String packageName) {
+    return librarySource.fullName.startsWith('/$packageName/');
   }
 
-  bool _isExportedRecursivaly(
-    LibraryElementWithVisibility lib,
-    Set<String> visited,
-  ) {
-    if (lib.isRelevant(whereLibrary)) {
-      if (lib.libTopLevelExportElements.any(whereElement)) {
-        return true;
-      }
-    }
-
-    return lib.exportedLibraries.any((exported) {
-      final name = exported.lib.librarySource.fullName;
-      if (!visited.contains(name)) {
-        return _isExportedRecursivaly(exported, visited..add(name));
-      }
-      return false;
+  bool liraryExports({required String className, required String fromPackage}) {
+    return findAllAvailableTopLevelElements().any((element) {
+      return element.name == className &&
+          (element.library?.isFromPackage(fromPackage) ?? false);
     });
   }
-}
 
-class LibraryElementWithVisibility {
-  LibraryElementWithVisibility(
-    this.lib,
-    Set<String> shown,
-    Set<String> hidden,
-    List<NamespaceCombinator> combinators,
-  )   : shown = shown.union(combinators.shown),
-        hidden = hidden.union(combinators.hidden);
-
-  LibraryElementWithVisibility.root(
-    LibraryElement lib,
-    List<NamespaceCombinator> combinators,
-  ) : this(lib, {}, {}, combinators);
-
-  final LibraryElement lib;
-  final Set<String> shown;
-  final Set<String> hidden;
-
-  bool isExported(Element e) {
-    if (hidden.isEmpty && shown.isEmpty) return true;
-    if (shown.isNotEmpty) return shown.contains(e.name);
-    return !hidden.contains(e.name);
+  /// Recursively loops at the import/export directives to know what is available
+  /// in the library.
+  ///
+  /// This function does not guarantees that the elements returned are unique.
+  /// It is possible for the same object to be present multiple times in the list.
+  Iterable<Element> findAllAvailableTopLevelElements() {
+    return _findAllAvailableTopLevelElements(
+      {},
+      checkExports: false,
+      key: _LibraryKey(
+        hideStatements: {},
+        showStatements: {},
+        librarySource: librarySource.fullName,
+      ),
+    );
   }
 
-  bool isRelevant(LibraryMatcher? whereLibrary) {
-    return whereLibrary?.call(lib) ?? true;
-  }
+  Iterable<Element> _findAllAvailableTopLevelElements(
+    Set<_LibraryKey> visitedLibraryPaths, {
+    required bool checkExports,
+    required _LibraryKey key,
+  }) sync* {
+    yield* topLevelElements;
 
-  Iterable<Element> get libTopLevelExportElements {
-    return lib.exportNamespace.definedNames.values.where(isExported);
-  }
+    final librariesToCheck = checkExports
+        ? libraryExports.map(_LibraryDirectives.fromExport).whereNotNull()
+        : libraryImports.map(_LibraryDirectives.fromImport).whereNotNull();
 
-  /// based on exportedLibraries from analyzer-4.1.0
-  /// lib/src/dart/element/element.dart
-  List<LibraryElementWithVisibility> get exportedLibraries {
-    final libraries = <LibraryElementWithVisibility>{};
-    for (final export in lib.libraryExports) {
-      final library = export.exportedLibrary;
-      if (library != null) {
-        libraries.add(LibraryElementWithVisibility(
-          library,
-          shown,
-          hidden,
-          export.combinators,
-        ));
+    for (final directive in librariesToCheck) {
+      if (!visitedLibraryPaths.add(directive.key)) {
+        continue;
       }
+
+      yield* directive.library
+          ._findAllAvailableTopLevelElements(
+        visitedLibraryPaths,
+        checkExports: true,
+        key: directive.key,
+      )
+          .where(
+        (element) {
+          return (directive.showStatements.isEmpty &&
+                  directive.hideStatements.isEmpty) ||
+              (directive.hideStatements.isNotEmpty &&
+                  !directive.hideStatements.contains(element.name)) ||
+              directive.showStatements.contains(element.name);
+        },
+      );
     }
-    return libraries.toList(growable: false);
   }
 }
 
-extension on Iterable<NamespaceCombinator> {
-  Set<String> get hidden =>
-      whereType<HideElementCombinator>().expand((e) => e.hiddenNames).toSet();
+class _LibraryDirectives {
+  _LibraryDirectives({
+    required this.hideStatements,
+    required this.showStatements,
+    required this.library,
+  });
 
-  Set<String> get shown =>
-      whereType<ShowElementCombinator>().expand((e) => e.shownNames).toSet();
+  static _LibraryDirectives? fromExport(LibraryExportElement export) {
+    final library = export.exportedLibrary;
+    if (library == null) return null;
+
+    final hideStatements = export.combinators
+        .whereType<HideElementCombinator>()
+        .expand((e) => e.hiddenNames)
+        .toSet();
+
+    final showStatements = export.combinators
+        .whereType<ShowElementCombinator>()
+        .expand((e) => e.shownNames)
+        .toSet();
+
+    return _LibraryDirectives(
+      hideStatements: hideStatements,
+      showStatements: showStatements,
+      library: library,
+    );
+  }
+
+  static _LibraryDirectives? fromImport(LibraryImportElement export) {
+    final library = export.importedLibrary;
+    if (library == null) return null;
+
+    final hideStatements = export.combinators
+        .whereType<HideElementCombinator>()
+        .expand((e) => e.hiddenNames)
+        .toSet();
+
+    final showStatements = export.combinators
+        .whereType<ShowElementCombinator>()
+        .expand((e) => e.shownNames)
+        .toSet();
+
+    return _LibraryDirectives(
+      hideStatements: hideStatements,
+      showStatements: showStatements,
+      library: library,
+    );
+  }
+
+  final Set<String> hideStatements;
+  final Set<String> showStatements;
+  final LibraryElement library;
+
+  _LibraryKey get key {
+    return _LibraryKey(
+      hideStatements: hideStatements,
+      showStatements: showStatements,
+      librarySource: library.source.fullName,
+    );
+  }
+}
+
+/// A unique key for an import/export statement, to avoid visiting a library twice
+/// as libraries sometimes have circular dependencies – which would cause an infinite loop.
+///
+/// We can't simply use the library path, as it's possible for the same library
+/// to be exported multiple time:
+///
+/// ```dart
+/// export 'library.dart' show A;
+/// export 'library.dart' show B;
+/// ```
+class _LibraryKey {
+  _LibraryKey({
+    required this.hideStatements,
+    required this.showStatements,
+    required this.librarySource,
+  });
+
+  final Set<String> hideStatements;
+  final Set<String> showStatements;
+  final String librarySource;
+
+  @override
+  bool operator ==(Object? other) {
+    return other is _LibraryKey &&
+        librarySource == other.librarySource &&
+        const SetEquality<String>()
+            .equals(hideStatements, other.hideStatements) &&
+        const SetEquality<String>()
+            .equals(showStatements, other.showStatements);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        librarySource,
+        const SetEquality<String>().hash(hideStatements),
+        const SetEquality<String>().hash(showStatements),
+      );
+
+  @override
+  String toString() {
+    return '(path: $librarySource, hide: $hideStatements, show: $showStatements)';
+  }
 }


### PR DESCRIPTION
After upgrading to newer versions of analyzer (e.g. 5.2) `Color` is recognized as a `dynamic` type. (We get it from the FieldElement.type).

Changes:
- This PR adds a workaround to get type name from AST node if returned type is `dynamic`.
- Fix generation of debugFillProperties 
