### PR TITLE
chore(theme_tailor, theme_tailor_annotation): RC 1.1.1

### DIFF
--- a/packages/theme_tailor/CHANGELOG.md
+++ b/packages/theme_tailor/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 1.1.1
+- Update documentation
 - Fix: required version of theme_tailor_annotation is 1.1.1
 
 # 1.1.0

--- a/packages/theme_tailor/CHANGELOG.md
+++ b/packages/theme_tailor/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.1
+- Fix: required version of theme_tailor_annotation is 1.1.1
+
 # 1.1.0
 - Generate constant themes if possible
 - Nullable fields are no longer required in a generated theme constructor

--- a/packages/theme_tailor/README.md
+++ b/packages/theme_tailor/README.md
@@ -282,7 +282,7 @@ If the following conditions are met, constant themes will be generated:
 ```dart
 const someOtherList = ['a','b'];
 
-@Tailor(constantThemes: true)
+@Tailor(requireStaticConst: true)
 class _$ConstantThemes {
   // This is correct
   static const someNumberList = [1, 2];

--- a/packages/theme_tailor/example/pubspec.lock
+++ b/packages/theme_tailor/example/pubspec.lock
@@ -454,7 +454,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.8"
+    version: "1.1.0"
   theme_tailor_annotation:
     dependency: "direct main"
     description:

--- a/packages/theme_tailor/example/pubspec.lock
+++ b/packages/theme_tailor/example/pubspec.lock
@@ -454,14 +454,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.1"
   theme_tailor_annotation:
     dependency: "direct main"
     description:
       path: "../../theme_tailor_annotation"
       relative: true
     source: path
-    version: "1.0.3"
+    version: "1.1.1"
   timing:
     dependency: transitive
     description:

--- a/packages/theme_tailor/example/pubspec.yaml
+++ b/packages/theme_tailor/example/pubspec.yaml
@@ -13,14 +13,14 @@ dependencies:
     sdk: flutter
 
   json_annotation: ^4.7.0
-  theme_tailor_annotation: ^1.0.0
+  theme_tailor_annotation: ^1.1.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.1.11
   json_serializable: ^6.3.2
-  theme_tailor: ^1.0.8
+  theme_tailor: ^1.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/theme_tailor/pubspec.yaml
+++ b/packages/theme_tailor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Code generator for Flutter's 3.0 ThemeExtension classes. 
   The generator can create themes and extensions on BuildContext 
   or ThemeData based on the lists of the theme properties
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/Iteo/theme_tailor
 issue_tracker: https://github.com/Iteo/theme_tailor/issues
 homepage: https://github.com/Iteo/theme_tailor
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.7.0
   source_gen: ^1.2.3
   source_helper: ^1.3.2
-  theme_tailor_annotation: ^1.0.3
+  theme_tailor_annotation: ^1.1.1
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/theme_tailor_annotation/CHANGELOG.md
+++ b/packages/theme_tailor_annotation/CHANGELOG.md
@@ -1,5 +1,9 @@
+# 1.1.1
+- Add `requireStaticConst` property to the `@Tailor` the annotation
+
 # 1.0.3
 - Build configuration. It is possible to configure `themes` within the build.yaml
+- Add `@ignore` annotation
 
 # 1.0.2
 - Fixed encoder declaration that prevented creating encoders for nullable types

--- a/packages/theme_tailor_annotation/pubspec.yaml
+++ b/packages/theme_tailor_annotation/pubspec.yaml
@@ -2,7 +2,7 @@ name: theme_tailor_annotation
 description: >
   Annotations for the Theme Tailor code-generator.
   This package does nothing without Theme Tailor.
-version: 1.0.3
+version: 1.1.1
 repository: https://github.com/Iteo/theme_tailor
 issue_tracker: https://github.com/Iteo/theme_tailor/issues
 homepage: https://github.com/Iteo/theme_tailor


### PR DESCRIPTION
Changes in the newest release 1.1.0 require update to the annotation package (missing `requireStaticConst` property)
Bumped up both versions to the same number to prevent further confusion 