### PR TITLE
fix(theme_tailor): DiagnosticableTreeMixin import

### DIFF
--- a/packages/theme_tailor/CHANGELOG.md
+++ b/packages/theme_tailor/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.1.1-dev
+- Fix DiagnosticableTreeMixin not being generated if package:flutter/foundation.dart was proceeded by other Flutter import
+
 # 1.1.1
 - Update documentation
 - Fix: required version of theme_tailor_annotation is 1.1.1

--- a/packages/theme_tailor/example/lib/constant_theme.dart
+++ b/packages/theme_tailor/example/lib/constant_theme.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: unused_element, unused_field
-
-import 'package:example/diagnosticable_lib.dart';
+import 'package:flutter/material.dart';
+import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
 
 part 'constant_theme.tailor.dart';
 

--- a/packages/theme_tailor/example/lib/diagnosticable.dart
+++ b/packages/theme_tailor/example/lib/diagnosticable.dart
@@ -1,5 +1,7 @@
-import 'package:flutter/foundation.dart';
+// ignore_for_file: directives_ordering
+
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
 
 part 'diagnosticable.tailor.dart';

--- a/packages/theme_tailor/example/lib/diagnosticable_lib.dart
+++ b/packages/theme_tailor/example/lib/diagnosticable_lib.dart
@@ -1,5 +1,7 @@
+// ignore_for_file: directives_ordering
+
 library diagnosticable;
 
-export 'package:flutter/foundation.dart';
 export 'package:flutter/material.dart';
+export 'package:flutter/foundation.dart';
 export 'package:theme_tailor_annotation/theme_tailor_annotation.dart';

--- a/packages/theme_tailor/example/lib/ignore_example.dart
+++ b/packages/theme_tailor/example/lib/ignore_example.dart
@@ -1,5 +1,6 @@
 import 'package:example/app_colors.dart';
-import 'package:example/diagnosticable_lib.dart';
+import 'package:flutter/material.dart';
+import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
 
 part 'ignore_example.tailor.dart';
 

--- a/packages/theme_tailor/lib/src/util/extension/library_element_extension.dart
+++ b/packages/theme_tailor/lib/src/util/extension/library_element_extension.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:theme_tailor/src/util/recursive_import_locator.dart';
 
+/// TODO(rongix): refactor it to not return all elements (unnecessary)
 extension LibraryElementExtension on LibraryElement {
   bool get hasFlutterDiagnosticableImport {
     return findAllAvailableTopLevelElements().any((element) {

--- a/packages/theme_tailor/lib/src/util/recursive_import_locator.dart
+++ b/packages/theme_tailor/lib/src/util/recursive_import_locator.dart
@@ -1,3 +1,4 @@
+// Based on:
 // From Freezed 2.3.2 packages/freezed/lib/src/tools/recursive_import_locator.dart
 // MIT License
 //
@@ -35,60 +36,57 @@ extension FindAllAvailableTopLevelElements on LibraryElement {
   /// This function does not guarantees that the elements returned are unique.
   /// It is possible for the same object to be present multiple times in the list.
   Iterable<Element> findAllAvailableTopLevelElements() {
-    return _findAllAvailableTopLevelElements(
-      {},
-      checkExports: false,
-      key: _LibraryKey(
-        hideStatements: {},
-        showStatements: {},
-        librarySource: librarySource.fullName,
-      ),
-    );
+    final elements = libraryImports
+        .imports()
+        .expand((import) => import.library._visibleElements({}, import.key));
+
+    return elements;
   }
 
-  Iterable<Element> _findAllAvailableTopLevelElements(
-    Set<_LibraryKey> visitedLibraryPaths, {
-    required bool checkExports,
-    required _LibraryKey key,
-  }) sync* {
+  Iterable<Element> _visibleElements(
+    Set<String> visitedPaths,
+    _LibraryKey key,
+  ) sync* {
     yield* topLevelElements;
 
-    final librariesToCheck = checkExports
-        ? libraryExports.map(_LibraryDirectives.fromExport).whereNotNull()
-        : libraryImports.map(_LibraryDirectives.fromImport).whereNotNull();
-
-    for (final directive in librariesToCheck) {
-      if (!visitedLibraryPaths.add(directive.key)) {
+    for (final directive in libraryExports.exports()) {
+      if (!visitedPaths.add(key.toString() + directive.key.toString())) {
         continue;
       }
 
       yield* directive.library
-          ._findAllAvailableTopLevelElements(
-        visitedLibraryPaths,
-        checkExports: true,
-        key: directive.key,
-      )
-          .where(
-        (element) {
-          return (directive.showStatements.isEmpty &&
-                  directive.hideStatements.isEmpty) ||
-              (directive.hideStatements.isNotEmpty &&
-                  !directive.hideStatements.contains(element.name)) ||
-              directive.showStatements.contains(element.name);
-        },
-      );
+          ._visibleElements(visitedPaths, directive.key)
+          .where(directive.elementIsExported);
     }
   }
 }
 
-class _LibraryDirectives {
-  _LibraryDirectives({
+extension on List<LibraryExportElement> {
+  Iterable<_LibraryDirective> exports() {
+    return map(_LibraryDirective.fromExport).whereNotNull();
+  }
+}
+
+extension on List<LibraryImportElement> {
+  Iterable<_LibraryDirective> imports() {
+    return map(_LibraryDirective.fromImport).whereNotNull();
+  }
+}
+
+class _LibraryDirective {
+  _LibraryDirective({
     required this.hideStatements,
     required this.showStatements,
     required this.library,
   });
 
-  static _LibraryDirectives? fromExport(LibraryExportElement export) {
+  bool elementIsExported(Element element) {
+    return (showStatements.isEmpty && hideStatements.isEmpty) ||
+        (hideStatements.isNotEmpty && !hideStatements.contains(element.name)) ||
+        showStatements.contains(element.name);
+  }
+
+  static _LibraryDirective? fromExport(LibraryExportElement export) {
     final library = export.exportedLibrary;
     if (library == null) return null;
 
@@ -102,14 +100,14 @@ class _LibraryDirectives {
         .expand((e) => e.shownNames)
         .toSet();
 
-    return _LibraryDirectives(
+    return _LibraryDirective(
       hideStatements: hideStatements,
       showStatements: showStatements,
       library: library,
     );
   }
 
-  static _LibraryDirectives? fromImport(LibraryImportElement export) {
+  static _LibraryDirective? fromImport(LibraryImportElement export) {
     final library = export.importedLibrary;
     if (library == null) return null;
 
@@ -123,7 +121,7 @@ class _LibraryDirectives {
         .expand((e) => e.shownNames)
         .toSet();
 
-    return _LibraryDirectives(
+    return _LibraryDirective(
       hideStatements: hideStatements,
       showStatements: showStatements,
       library: library,

--- a/packages/theme_tailor/pubspec.yaml
+++ b/packages/theme_tailor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Code generator for Flutter's 3.0 ThemeExtension classes. 
   The generator can create themes and extensions on BuildContext 
   or ThemeData based on the lists of the theme properties
-version: 1.1.1
+version: 1.1.1-dev
 repository: https://github.com/Iteo/theme_tailor
 issue_tracker: https://github.com/Iteo/theme_tailor/issues
 homepage: https://github.com/Iteo/theme_tailor

--- a/packages/theme_tailor_toolbox/example/pubspec.lock
+++ b/packages/theme_tailor_toolbox/example/pubspec.lock
@@ -470,14 +470,14 @@ packages:
       path: "../../theme_tailor"
       relative: true
     source: path
-    version: "1.0.8"
+    version: "1.1.1"
   theme_tailor_annotation:
     dependency: "direct main"
     description:
       path: "../../theme_tailor_annotation"
       relative: true
     source: path
-    version: "1.0.3"
+    version: "1.1.1"
   theme_tailor_toolbox:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Fixes a case for DiagnosticableTreeMixin not being generated even in foundation.dart is imported (Happened when there were other flutter imports proceeding it) 