### PR TITLE
chore(theme_tailor, theme_tailor_anotation): RC 1.2.0

### DIFF
--- a/packages/theme_tailor/CHANGELOG.md
+++ b/packages/theme_tailor/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.2.0-dev
-- Generate static getters, allowing the theme to be updated on hot reload.
+# 1.2.0
+- Added `generateStaticGetters` property to `Tailor` and `TailorComponent` to support hot-reload
 - Build configuration. It is possible to configure `themeGetter`, `requireStaticConst` and `generateStaticGetters` annotation properties within the build.yaml with: theme_getter and require_static_const (all keys and values for enums are snake_case)
+- Required version of theme_tailor_annotation is 1.2.0
 
 # 1.1.2
 - Fix: DiagnosticableTreeMixin not being generated if package:flutter/foundation.dart was proceeded by other Flutter import

--- a/packages/theme_tailor/README.md
+++ b/packages/theme_tailor/README.md
@@ -297,7 +297,7 @@ It is possible to force generate constant themes using `Tailor(requireStaticCons
 In this case fields that do not meet conditions will be excluded from the theme and a warning will be printed.
 
 ## Hot reload support
-To enable hot reload support, use the `generateStaticGetters` property of the `@Tailor()` annotation. This will generate static getters that allow updating theme properties on hot reload. The getters will conditionally return either the theme itself (if kDebugMode == true) or the final theme otherwise.
+To enable hot reload support, use the `generateStaticGetters` property of the `@Tailor()` and `@TailorComponent` annotations. This will generate static getters that allow updating theme properties on hot reload. The getters will conditionally return either the theme itself (if kDebugMode == true) or the final theme otherwise.
 
 To use hot reload with Tailor, make sure to follow these requirements:
 - Import `package:flutter/foundation.dart` as the option depends on `kDebugMode` from this package

--- a/packages/theme_tailor/pubspec.yaml
+++ b/packages/theme_tailor/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Code generator for Flutter's 3.0 ThemeExtension classes. 
   The generator can create themes and extensions on BuildContext 
   or ThemeData based on the lists of the theme properties
-version: 1.2.0-dev
+version: 1.2.0
 repository: https://github.com/Iteo/theme_tailor
 issue_tracker: https://github.com/Iteo/theme_tailor/issues
 homepage: https://github.com/Iteo/theme_tailor
@@ -22,7 +22,7 @@ dependencies:
   source_gen_test: ^1.0.4
   source_gen: ^1.2.3
   source_helper: ^1.3.2
-  theme_tailor_annotation: ^1.1.1
+  theme_tailor_annotation: ^1.2.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/theme_tailor_annotation/CHANGELOG.md
+++ b/packages/theme_tailor_annotation/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.2.0-dev
+# 1.2.0
 - Add `generateStaticGetters` property to `@Tailor` and `@TailorComponent` which adds support for hot reload for const fields
 - `requireStaticConst` is now available for `@TailorComponent`
 - Changes how `themeGetter` and `requireStaticConst` are handled internally by the generator, now these properties are nullable

--- a/packages/theme_tailor_annotation/pubspec.yaml
+++ b/packages/theme_tailor_annotation/pubspec.yaml
@@ -2,7 +2,7 @@ name: theme_tailor_annotation
 description: >
   Annotations for the Theme Tailor code-generator.
   This package does nothing without Theme Tailor.
-version: 1.2.0-dev
+version: 1.2.0
 repository: https://github.com/Iteo/theme_tailor
 issue_tracker: https://github.com/Iteo/theme_tailor/issues
 homepage: https://github.com/Iteo/theme_tailor


### PR DESCRIPTION
RC 1.2.0 for generator and annotation packages 

(expected to fail test because generator depends on unreleased version of the annotation)