### PR TITLE
feat(theme_tailor): disable formatting for generated code

### DIFF
--- a/packages/theme_tailor/README.md
+++ b/packages/theme_tailor/README.md
@@ -332,6 +332,7 @@ The generator will use properties from build.yaml or default values for null pro
 | theme_getter          | themeGetter         | on_build_context_props | <b>String</b> (ThemeGetter.name):<br><br>none \ on_theme_data \ on_theme_data_props \ on_build_context \ on_build_context_props |
 | theme_class_name      | themeClassName      | null                   | <b>String</b> For custom Theme if you don't want<br>use Material's Theme. Example: FluentTheme                                  |
 | theme_data_class_name | themeDataClassName  | null                   | <b>String</b> For custom ThemeData if you don't want<br>use Material's ThemeData FluentThemeData                                |
+| format                | format              | true                   | <b>Bool</b> Enable/disable dart formatting for generated code                                                                   |
 
 ### Material's theme_getter
 ```yaml

--- a/packages/theme_tailor/lib/builder.dart
+++ b/packages/theme_tailor/lib/builder.dart
@@ -8,10 +8,11 @@ import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
 
 /// Function used by the build runner
 Builder themeTailorBuilder(BuilderOptions options) {
+  final format = options.config['format'] != false;
   return PartBuilder(
     [TailorAnnotationsGenerator(TailorMixin.fromJson(options.config))],
     formatOutput: (str, version) {
-      if (options.config['format'] == false) return str;
+      if (format) return str;
 
       return DartFormatter(languageVersion: version).format(str);
     },
@@ -21,8 +22,7 @@ Builder themeTailorBuilder(BuilderOptions options) {
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
-// dart format off
-''',
+''' + (format ? '' : '// dart format off\n'),
     options: options,
   );
 }

--- a/packages/theme_tailor/lib/builder.dart
+++ b/packages/theme_tailor/lib/builder.dart
@@ -21,6 +21,7 @@ Builder themeTailorBuilder(BuilderOptions options) {
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+// dart format off
 ''',
     options: options,
   );


### PR DESCRIPTION
Question: is this something that should be put behind a config flag?